### PR TITLE
Add VA-IDEAS Quarto presentation deck

### DIFF
--- a/Presentations/VA-IDEAS/custom.css
+++ b/Presentations/VA-IDEAS/custom.css
@@ -1,0 +1,22 @@
+.reveal h1,
+.reveal h2,
+.reveal h3 {
+  letter-spacing: 0.02em;
+}
+
+.reveal section {
+  font-size: 28px;
+}
+
+.reveal .callout-note,
+.reveal .callout-important {
+  border-left: 4px solid #2563eb;
+  background: #eff6ff;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+}
+
+.reveal .callout-important {
+  border-left-color: #dc2626;
+  background: #fef2f2;
+}

--- a/Presentations/VA-IDEAS/index.qmd
+++ b/Presentations/VA-IDEAS/index.qmd
@@ -1,0 +1,126 @@
+---
+title: "VA-IDEAS"
+subtitle: "Prediction, Fairness, and Complex Bayesian Hierarchical Models"
+author: "Ben Brintz"
+institute: "Research Themes"
+format:
+  revealjs:
+    theme: white
+    transition: fade
+    incremental: true
+    slideNumber: true
+    css: custom.css
+---
+
+## Research threads at a glance
+
+::: {.columns}
+::: {.column width="50%"}
+- Prediction and decision support
+- Fairness-aware evaluation
+- Bayesian hierarchical modeling
+- Imperfect detection
+- Translational, domain-driven models
+:::
+
+::: {.column width="50%"}
+- Infectious disease dynamics (SEIR)
+- Behavioral signal detection
+- Call volume spike detection
+- Uncertainty quantification for action
+- Communicating results to stakeholders
+:::
+:::
+
+---
+
+## Prediction + fairness
+
+- Build models that perform well *and* are transparent about trade-offs
+- Emphasize calibration, subgroup performance, and equitable utility
+- Pair algorithmic outputs with decision thresholds that are defensible
+
+::: {.callout-note}
+**Goal:** decisions that are both accurate and equitable.
+:::
+
+---
+
+## Complex Bayesian hierarchical models
+
+- Multi-level structure to share information across sites, groups, and time
+- Partial pooling to stabilize estimates in sparse regimes
+- Rich latent processes for detection, transmission, and reporting
+
+::: {.fragment}
+**Why it matters:** hierarchical structure turns noisy, incomplete data into actionable signals.
+:::
+
+---
+
+## Imperfect detection: the core challenge
+
+- Observed data are often a filtered version of the truth
+- Detection depends on resources, behavior, and system delays
+- Models must explicitly separate *process* from *observation*
+
+::: {.callout-important}
+Imperfect detection is not a nuisance—it is the mechanism that shapes what we can observe.
+:::
+
+---
+
+## Application: SEIR models with imperfect detection
+
+- Embed detection sub-models inside compartmental dynamics
+- Jointly infer incidence and observation processes
+- Quantify uncertainty in both transmission and reporting
+
+::: {.fragment}
+**Outcome:** more realistic forecasts and robust scenario planning.
+:::
+
+---
+
+## Application: detecting call spikes
+
+- Treat call volume as a latent process with observation noise
+- Hierarchical priors borrow strength across regions and time
+- Real-time detection focuses on *signals of change* rather than raw counts
+
+::: {.fragment}
+**Outcome:** faster identification of operational strain and emerging issues.
+:::
+
+---
+
+## Model workflow
+
+1. Define the scientific question and action thresholds
+2. Build hierarchical structure for stability
+3. Encode detection/measurement processes
+4. Validate with posterior predictive checks
+5. Communicate uncertainty clearly
+
+---
+
+## Current focus areas
+
+- Fairness-aware evaluation for predictive tools
+- Robust estimation under imperfect detection
+- Forecasting pipelines for infectious disease and operational signals
+- Bridging model outputs to real decisions
+
+---
+
+## Looking ahead
+
+- Integrating causal reasoning with hierarchical prediction
+- Adaptive monitoring for rapid response
+- Decision support that anticipates equity impacts
+
+---
+
+## Thank you
+
+Questions or collaborations welcome.

--- a/Presentations/index.qmd
+++ b/Presentations/index.qmd
@@ -35,5 +35,6 @@ a:hover, a:active {
 
 <div class="presentations-list">
   <a href="/Presentations/mmdis/">Measuring and Mitigating Disparity of Decision-Making Tools</a><br>
-  <a href="/Presentations/seir-n-mixture/">SEIR N-mixture Model</a>
+  <a href="/Presentations/seir-n-mixture/">SEIR N-mixture Model</a><br>
+  <a href="/Presentations/VA-IDEAS/">VA-IDEAS</a>
 </div>


### PR DESCRIPTION
### Motivation
- Introduce a new presentation summarizing research themes around prediction, fairness, and complex Bayesian hierarchical models including imperfect detection and applications to SEIR models and call-spike detection.

### Description
- Add a new Quarto revealjs presentation at `Presentations/VA-IDEAS/index.qmd` that outlines prediction/fairness, hierarchical modeling, imperfect detection, SEIR applications, call spike detection, and workflow items.
- Add presentation-specific styling in `Presentations/VA-IDEAS/custom.css` to adjust typography and callout appearance.
- Link the new deck from the presentations index by updating `Presentations/index.qmd` to include `VA-IDEAS` in the list.

### Testing
- Attempted to render the deck with `quarto render Presentations/VA-IDEAS/index.qmd`, but the command failed because Quarto is not installed in the environment.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696948725dc4832aa74ab1c986a1db3b)